### PR TITLE
Add monad transformer, use newtype wrapper

### DIFF
--- a/keycloak-hs.cabal
+++ b/keycloak-hs.cabal
@@ -48,6 +48,7 @@ library
         jose >=0.8 && <0.9,
         lens >=4.17 && <4.20,
         lens-aeson >=1.1 && <1.2,
+        monad-time >= 0.3 && <0.4,
         mtl >=2.2 && <2.3,
         string-conversions >=0.4 && <0.5,
         safe >=0.3 && <0.4,

--- a/keycloak-hs.cabal
+++ b/keycloak-hs.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 name: keycloak-hs
-version: 2.1.0
+version: 3.0.0
 license: BSD3
 license-file: LICENSE
 copyright: 2019 Corentin Dupont

--- a/src/Keycloak/Utils.hs
+++ b/src/Keycloak/Utils.hs
@@ -24,120 +24,113 @@ import           Crypto.JWT as JWT
 
 
 -- | Perform post to Keycloak.
-keycloakPost :: (Postable dat, Show dat) => Path -> dat -> JWT -> Keycloak BL.ByteString
+keycloakPost :: (Postable dat, Show dat, MonadIO m) => Path -> dat -> JWT -> KeycloakT m BL.ByteString
 keycloakPost path dat jwt = do
-  realm <- view (confAdapterConfig.confRealm)
-  baseUrl <- view (confAdapterConfig.confAuthServerUrl)
+  (realm,baseUrl) <- viewRealmAndUrl
   let opts = W.defaults & W.header "Authorization" .~ ["Bearer " <> (convertString $ encodeCompact jwt)]
   let url = (unpack $ baseUrl <> "/realms/" <> realm <> "/" <> path) 
   info $ "Issuing KEYCLOAK POST with url: " ++ (show url) 
   debug $ "  data: " ++ (show dat) 
   --debug $ "  headers: " ++ (show $ opts ^. W.headers) 
-  eRes <- C.try $ liftIO $ W.postWith opts url dat
+  eRes <- liftIO $ C.try $ W.postWith opts url dat
   case eRes of 
     Right res -> do
       return $ fromJust $ res ^? responseBody
     Left er -> do
       warn $ "Keycloak HTTP error: " ++ (show er)
-      throwError $ HTTPError er
+      kcError $ HTTPError er
 
 -- | Perform post to Keycloak, without token.
-keycloakPost' :: (Postable dat, Show dat) => Path -> dat -> Keycloak BL.ByteString
+keycloakPost' :: (Postable dat, Show dat, MonadIO m) => Path -> dat -> KeycloakT m BL.ByteString
 keycloakPost' path dat = do 
-  realm <- view (confAdapterConfig.confRealm)
-  baseUrl <- view (confAdapterConfig.confAuthServerUrl)
+  (realm,baseUrl) <- viewRealmAndUrl
   let opts = W.defaults
   let url = (unpack $ baseUrl <> "/realms/" <> realm <> "/" <> path) 
   info $ "Issuing KEYCLOAK POST with url: " ++ (show url) 
   debug $ "  data: " ++ (show dat) 
   --debug $ "  headers: " ++ (show $ opts ^. W.headers) 
-  eRes <- C.try $ liftIO $ W.postWith opts url dat
+  eRes <- liftIO $ C.try $ W.postWith opts url dat
   case eRes of 
     Right res -> do
       return $ fromJust $ res ^? responseBody
     Left er -> do
       warn $ "Keycloak HTTP error: " ++ (show er)
-      throwError $ HTTPError er
+      kcError $ HTTPError er
 
 -- | Perform delete to Keycloak.
-keycloakDelete :: Path -> JWT -> Keycloak ()
+keycloakDelete :: MonadIO m => Path -> JWT -> KeycloakT m ()
 keycloakDelete path jwt = do 
-  realm <- view (confAdapterConfig.confRealm)
-  baseUrl <- view (confAdapterConfig.confAuthServerUrl)
+  (realm,baseUrl) <- viewRealmAndUrl
   let opts = W.defaults & W.header "Authorization" .~ ["Bearer " <> (convertString $ encodeCompact jwt)]
   let url = (unpack $ baseUrl <> "/realms/" <> realm <> "/" <> path) 
   info $ "Issuing KEYCLOAK DELETE with url: " ++ (show url) 
   debug $ "  headers: " ++ (show $ opts ^. W.headers) 
-  eRes <- C.try $ liftIO $ W.deleteWith opts url
+  eRes <- liftIO $ C.try $ W.deleteWith opts url
   case eRes of 
     Right _ -> return ()
     Left er -> do
       warn $ "Keycloak HTTP error: " ++ (show er)
-      throwError $ HTTPError er
+      kcError $ HTTPError er
 
 -- | Perform get to Keycloak on admin API
-keycloakGet :: Path -> JWT -> Keycloak BL.ByteString
-keycloakGet path tok = do 
-  realm <- view (confAdapterConfig.confRealm)
-  baseUrl <- view (confAdapterConfig.confAuthServerUrl)
+keycloakGet :: MonadIO m => Path -> JWT -> KeycloakT m BL.ByteString
+keycloakGet path tok = do
+  (realm,baseUrl) <- viewRealmAndUrl
   let opts = W.defaults & W.header "Authorization" .~ ["Bearer " <> (convertString $ encodeCompact tok)]
   let url = (unpack $ baseUrl <> "/realms/" <> realm <> "/" <> path) 
   info $ "Issuing KEYCLOAK GET with url: " ++ (show url) 
   debug $ "  headers: " ++ (show $ opts ^. W.headers) 
-  eRes <- C.try $ liftIO $ W.getWith opts url
+  eRes <- liftIO $ C.try $ W.getWith opts url
   case eRes of 
     Right res -> do
       return $ fromJust $ res ^? responseBody
     Left er -> do
       warn $ "Keycloak HTTP error: " ++ (show er)
-      throwError $ HTTPError er
+      kcError $ HTTPError er
 
 -- | Perform get to Keycloak on admin API, without token
-keycloakGet' :: Path -> Keycloak BL.ByteString
-keycloakGet' path = do 
-  realm <- view (confAdapterConfig.confRealm)
-  baseUrl <- view (confAdapterConfig.confAuthServerUrl)
+keycloakGet' :: MonadIO m => Path -> KeycloakT m BL.ByteString
+keycloakGet' path = do
+  (realm,baseUrl) <- viewRealmAndUrl
   let opts = W.defaults
   let url = (unpack $ baseUrl <> "/realms/" <> realm <> "/" <> path) 
   info $ "Issuing KEYCLOAK GET with url: " ++ (show url) 
   debug $ "  headers: " ++ (show $ opts ^. W.headers) 
-  eRes <- C.try $ liftIO $ W.getWith opts url
-  case eRes of 
+  eRes <- liftIO $ C.try $ W.getWith opts url
+  case eRes of
     Right res -> do
       return $ fromJust $ res ^? responseBody
     Left er -> do
       warn $ "Keycloak HTTP error: " ++ (show er)
-      throwError $ HTTPError er
+      kcError $ HTTPError er
 
 
 -- | Perform get to Keycloak on admin API
-keycloakAdminGet :: Path -> JWT -> Keycloak BL.ByteString
+keycloakAdminGet :: MonadIO m => Path -> JWT -> KeycloakT m BL.ByteString
 keycloakAdminGet path tok = do 
-  realm <- view (confAdapterConfig.confRealm)
-  baseUrl <- view (confAdapterConfig.confAuthServerUrl)
+  (realm,baseUrl) <- viewRealmAndUrl
   let opts = W.defaults & W.header "Authorization" .~ ["Bearer " <> (convertString $ encodeCompact tok)]
   let url = (unpack $ baseUrl <> "/admin/realms/" <> realm <> "/" <> path) 
   info $ "Issuing KEYCLOAK GET with url: " ++ (show url) 
   debug $ "  headers: " ++ (show $ opts ^. W.headers) 
-  eRes <- C.try $ liftIO $ W.getWith opts url
+  eRes <- liftIO $ C.try $ W.getWith opts url
   case eRes of 
     Right res -> do
       return $ fromJust $ res ^? responseBody
     Left er -> do
       warn $ "Keycloak HTTP error: " ++ (show er)
-      throwError $ HTTPError er
+      kcError $ HTTPError er
 
 -- | Perform post to Keycloak.
-keycloakAdminPost :: (Postable dat, Show dat) => Path -> dat -> JWT -> Keycloak BL.ByteString
+keycloakAdminPost :: (Postable dat, Show dat, MonadIO m) => Path -> dat -> JWT -> KeycloakT m BL.ByteString
 keycloakAdminPost path dat tok = do 
-  realm <- view (confAdapterConfig.confRealm)
-  baseUrl <- view (confAdapterConfig.confAuthServerUrl)
+  (realm,baseUrl) <- viewRealmAndUrl
   let opts = W.defaults & W.header "Authorization" .~ ["Bearer " <> (convertString $ encodeCompact tok)]
   let url = (unpack $ baseUrl <> "/admin/realms/" <> realm <> "/" <> path) 
   info $ "Issuing KEYCLOAK POST with url: " ++ (show url) 
   debug $ "  data: " ++ (show dat) 
   --debug $ "  headers: " ++ (show $ opts ^. W.headers) 
-  eRes <- C.try $ liftIO $ W.postWith opts url dat
+  eRes <- liftIO $ C.try $ W.postWith opts url dat
   case eRes of 
     Right res -> do
       debug $ (show eRes)
@@ -145,29 +138,39 @@ keycloakAdminPost path dat tok = do
       return $ convertString $ L.last $ T.split (== '/') $ convertString $ fromJust $ lookup "Location" hs
     Left er -> do
       warn $ "Keycloak HTTP error: " ++ (show er)
-      throwError $ HTTPError er
+      kcError $ HTTPError er
 
 -- | Perform put to Keycloak.
-keycloakAdminPut :: (Putable dat, Show dat) => Path -> dat -> JWT -> Keycloak ()
+keycloakAdminPut :: (Putable dat, Show dat, MonadIO m) => Path -> dat -> JWT -> KeycloakT m ()
 keycloakAdminPut path dat tok = do 
-  realm <- view (confAdapterConfig.confRealm)
-  baseUrl <- view (confAdapterConfig.confAuthServerUrl)
+  (realm,baseUrl) <- viewRealmAndUrl
   let opts = W.defaults & W.header "Authorization" .~ ["Bearer " <> (convertString $ encodeCompact tok)]
   let url = (unpack $ baseUrl <> "/admin/realms/" <> realm <> "/" <> path) 
   info $ "Issuing KEYCLOAK PUT with url: " ++ (show url) 
   debug $ "  data: " ++ (show dat) 
   debug $ "  headers: " ++ (show $ opts ^. W.headers) 
-  eRes <- C.try $ liftIO $ W.putWith opts url dat
+  eRes <- liftIO $ C.try $ W.putWith opts url dat
   case eRes of 
     Right _ -> return ()
     Left er -> do
       warn $ "Keycloak HTTP error: " ++ (show er)
-      throwError $ HTTPError er
+      kcError $ HTTPError er
 
+kcError :: Monad m => KCError -> KeycloakT m a
+kcError = KeycloakT . throwError
+
+viewRealmAndUrl :: Monad m => KeycloakT m (Realm,ServerURL)
+viewRealmAndUrl = do
+  realm <- viewConfig (confAdapterConfig.confRealm)
+  baseUrl <- viewConfig (confAdapterConfig.confAuthServerUrl)
+  pure (realm,baseUrl)
+
+viewConfig :: Monad m => Getting b KCConfig b -> KeycloakT m b
+viewConfig = KeycloakT . view
 
 -- * Helpers
 
-debug, warn, info, err :: (MonadIO m) => String -> m ()
+debug, warn, info, err :: MonadIO m => String -> m ()
 debug s = liftIO $ debugM "Keycloak" s
 info s  = liftIO $ infoM "Keycloak" s
 warn s  = liftIO $ warningM "Keycloak" s
@@ -177,8 +180,5 @@ getErrorStatus :: KCError -> Maybe Status
 getErrorStatus (HTTPError (HttpExceptionRequest _ (StatusCodeException r _))) = Just $ HC.responseStatus r
 getErrorStatus _ = Nothing
 
-try :: MonadError a m => m b -> m (Either a b)
-try act = catchError (Right <$> act) (return . Left)
-
-
-
+try :: Monad m => KeycloakT m b -> KeycloakT m (Either KCError b)
+try (KeycloakT act) = KeycloakT $ catchError (Right <$> act) (return . Left)


### PR DESCRIPTION
A transformer is needed for keycloak to be used in any project of size. The newtype wrapper avoids leaking abstraction such as the MonadReader or MonadExcept context into the consuming application, so they can use their own ReaderT or ExceptT in the monad stack without issue.